### PR TITLE
Remove bash-specific syntax from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,11 @@ all_clean: clean
 	cd $(LIBPATH)    ; $(MAKE) clean
 
 install:
-	mkdir -p $(PREFIX)/{bin,etc,lib,data,python}
+	mkdir -p $(PREFIX)/bin
+	mkdir -p $(PREFIX)/etc
+	mkdir -p $(PREFIX)/lib
+	mkdir -p $(PREFIX)/data
+	mkdir -p $(PREFIX)/python
 	cp -a main/oorb $(PREFIX)/bin/
 	cp -a main/oorb.conf $(PREFIX)/etc/
 	cp -a lib/* $(PREFIX)/lib/


### PR DESCRIPTION
Note that eups requests bin/env sh

On ubuntu sh is dash which is a much closer relative of sh than bash
(the sh implementation on Red Hat  / OSX)
