### PR TITLE
use curl instead of wget

### DIFF
--- a/data/JPL_ephemeris/Makefile
+++ b/data/JPL_ephemeris/Makefile
@@ -32,7 +32,8 @@ include ../../Makefile.include
 # TYPE OF EPHEMERIS [405|406|430|431]
 EPH_TYPE ?= 430
 # FTP client
-FTP_CLIENT = wget
+#FTP_CLIENT = wget -nv -c
+FTP_CLIENT = curl -L -O -\# -C - -f
 # Output name of the program:
 EPH_BIN = de$(EPH_TYPE).dat
 # Name of ascii-to-binary converter program source file:
@@ -101,7 +102,7 @@ $(TESTER): modules $(TEST_SRC)
 
 # Build input file for ascii-to-binary converter:
 $(EPH_INPUT):
-	$(FTP_CLIENT) ftp://ssd.jpl.nasa.gov/pub/eph/planets/ascii/de$(EPH_TYPE)/*
+	for F in $(EPH_ASCII_DE$(EPH_TYPE)) testpo.$(EPH_TYPE); do $(FTP_CLIENT) ftp://ssd.jpl.nasa.gov/pub/eph/planets/ascii/de$(EPH_TYPE)/$$F; done
 	cat $(EPH_ASCII_DE$(EPH_TYPE)) > $(EPH_INPUT)
 
 # Write back-up:


### PR DESCRIPTION
Moved patch from https://github.com/mjuric/conda-lsst/blob/master/etc/patches/oorb/015-use-curl.patch to here, to use curl instead of wget.