### PR TITLE
Make sure MAKEFLAGS is not set before building oorb

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -22,6 +22,9 @@ build()
 {
 	PKGROOT="$PWD"
 
+	# Passing MAKEFLAGS can lead to odd errors in the gfortran compiler
+	( unset MAKEFLAGS )
+
 	# built & test OpenOrb
 	( cd main && make oorb )
 


### PR DESCRIPTION
Passing MAKEFLAGS lead to errors in the gfortran compiler, where the presence of flags caused the compiler to become case sensitive. It is unclear why this happens, but unsetting any flags passed to `make` appears to fix the problem.