### PR TITLE
Update configs to allow conda compiler usage.

### DIFF
--- a/configure
+++ b/configure
@@ -201,6 +201,12 @@ elif [[ $1 == gfortran ]] ; then
     echo 'FC_SHARED = $(FC_SHARED_GFORTRAN)' >> $include_file
     echo 'F2PY_FCOMPILER = $(F2PY_FCOMPILER_GFORTRAN)' >> $include_file
 
+elif [[ $1 == conda ]] ; then
+    echo "FC = ${FC}" > $include_file
+    echo "FCOPTIONS = $FFLAGS $LDFLAGS -cpp ""$ADDOPTS" >> $include_file
+    echo 'FC_INC = $(FC_INC_GFORTRAN)' >> $include_file
+    echo 'FC_SHARED = $(FC_SHARED_GFORTRAN)' >> $include_file
+    echo 'F2PY_FCOMPILER = $(F2PY_FCOMPILER_GFORTRAN)' >> $include_file
 else
 
     echo Erroneous compiler: $1

--- a/data/JPL_ephemeris/Makefile
+++ b/data/JPL_ephemeris/Makefile
@@ -101,11 +101,11 @@ test : $(TESTER) $(EPH_BIN) testpo.$(EPH_TYPE)
 
 # Compile ascii-to-binary converter:
 $(CONVERTER): $(CONV_SRC) ../../lib/liboorb.a
-	$(FC) -o $(CONVERTER) $(FC_INC)../../build $(CONV_SRC) ../../lib/liboorb.a $(ADDLIBS) 
+	$(FC) -o $(CONVERTER) $(FCOPTIONS) $(FC_INC)../../build $(CONV_SRC) ../../lib/liboorb.a $(ADDLIBS)
 
 # Compile tester:
 $(TESTER): $(TEST_SRC) ../../lib/liboorb.a
-	$(FC) -o $(TESTER) $(FC_INC)../../build $(TESTER_SRC) ../../lib/liboorb.a $(ADDLIBS) 
+	$(FC) -o $(TESTER) $(FCOPTIONS) $(FC_INC)../../build $(TESTER_SRC) ../../lib/liboorb.a $(ADDLIBS)
 
 # Download individual ephemeris files (via a temp file, so that partial downloads aren't
 # seen as successful by make

--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -7,15 +7,12 @@ _ensure_exists()
 
 prep()
 {
-	# check for system prerequisites
-	_ensure_exists gfortran
-
 	default_prep
 }
 
 config()
 {
-	./configure gfortran opt --with-pyoorb
+	./configure conda opt --with-pyoorb
 }
 
 build()


### PR DESCRIPTION
Modify the makefile to add flags for 'conda' when building.
Modify eupspkg to use the 'conda' option. 
This makes 
`./config conda opt --with-python` 
a valid configure and then build (using conda installed gcc and lapack) an option.